### PR TITLE
chore: add dependabot; github action updates; correct flake8 to ignore .venv environment folder

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,5 +5,5 @@ exclude=
   *.pot,
   *.py[co],
   __pycache__,
-  venv,
+  .venv,
   .env

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      python-packages:
+        patterns:
+          - "*"
+    target-branch: "develop"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,8 +1,9 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: CI
+name: Continuous Integration
 on:
+  pull_request:
   push:
   workflow_dispatch:
 permissions:
@@ -11,11 +12,11 @@ jobs:
   continuous_integration:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.13"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
- Add Dependabot to project.
- Update Github Actions.
- Correct exclusion of `venv` to `.venv` to properly ignore environment folder.